### PR TITLE
Quaternion overhaul

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.0-beta2"
 manifest_format = "2.0"
-project_hash = "4903dd5d84faaf8c3eae7adbcef17ba971308241"
+project_hash = "07e8af666232824fc87e7f7155a52487d33dbbf4"
 
 [[deps.Accessors]]
 deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "LinearAlgebra", "MacroTools", "Requires", "Test"]
@@ -245,6 +245,12 @@ version = "0.9.3"
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 version = "1.6.0"
+
+[[deps.EpollShim_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8e9441ee83492030ace98f9789a654a6d0b1f643"
+uuid = "2702e6a9-849d-5ed8-8c21-79e8b8f9ee43"
+version = "0.0.20230411+0"
 
 [[deps.ExceptionUnwrapping]]
 deps = ["Test"]
@@ -1118,7 +1124,7 @@ uuid = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
 version = "0.2.0"
 
 [[deps.Wayland_jll]]
-deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
+deps = ["Artifacts", "EpollShim_jll", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
 git-tree-sha1 = "ed8d92d9774b077c53e1da50fd81a36af3744c1c"
 uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
 version = "1.21.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SatelliteDynamics = "0e7c1a32-1b9f-5532-88a4-e668712d6a4c"
 SatelliteToolbox = "6ac157d9-b43d-51bb-8fab-48bf53814f4a"
 SatelliteToolboxGeomagneticField = "9fc549ba-b5d7-49a2-b268-8171e5fb6e89"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]

--- a/src/ADCSSims.jl
+++ b/src/ADCSSims.jl
@@ -26,7 +26,7 @@ include("mekf.jl")
 include("simulation.jl")
 include("plots.jl")
 
-export AbstractQuaternion, Quaternion
+export Quaternion
 export NadirSensor, StarTracker, SunSensor, in_fov, available, qerr, estimateq
 export ReactionWheel, stribeck, deadzone_compensation, saturation_compensation
 export PDController, calculate_torque, decompose_torque

--- a/src/ADCSSims.jl
+++ b/src/ADCSSims.jl
@@ -26,7 +26,7 @@ include("mekf.jl")
 include("simulation.jl")
 include("plots.jl")
 
-export Quaternion
+export Quaternion, QuaternionF16, QuaternionF32, QuaternionF64
 export NadirSensor, StarTracker, SunSensor, in_fov, available, qerr, estimateq
 export ReactionWheel, stribeck, deadzone_compensation, saturation_compensation
 export PDController, calculate_torque, decompose_torque

--- a/src/ADCSSims.jl
+++ b/src/ADCSSims.jl
@@ -26,7 +26,7 @@ include("mekf.jl")
 include("simulation.jl")
 include("plots.jl")
 
-export Quaternion, QuaternionF16, QuaternionF32, QuaternionF64
+export Quaternion, QuaternionF16, QuaternionF32, QuaternionF64, rotvec
 export NadirSensor, StarTracker, SunSensor, in_fov, available, qerr, estimateq
 export ReactionWheel, stribeck, deadzone_compensation, saturation_compensation
 export PDController, calculate_torque, decompose_torque

--- a/src/ADCSSims.jl
+++ b/src/ADCSSims.jl
@@ -3,6 +3,8 @@ module ADCSSims
 using Accessors
 using ConcreteStructs
 
+using StaticArrays
+
 using SatelliteDynamics
 using SatelliteToolboxGeomagneticField
 
@@ -24,7 +26,7 @@ include("mekf.jl")
 include("simulation.jl")
 include("plots.jl")
 
-export Quaternion, scalar, vector, rotvec, toeuler
+export AbstractQuaternion, Quaternion
 export NadirSensor, StarTracker, SunSensor, in_fov, available, qerr, estimateq
 export ReactionWheel, stribeck, deadzone_compensation, saturation_compensation
 export PDController, calculate_torque, decompose_torque

--- a/src/control.jl
+++ b/src/control.jl
@@ -7,7 +7,7 @@ end
 function calculate_torque(PD::PDController, qtarget, qestimated, w, wtarget)
     qrel = qtarget * conj(qestimated) # TODO: should it be conj(qtarget)?
     werr = w - wtarget
-    return -sign(scalar(qrel)) * PD.Kp * vector(qrel) - PD.Kd * werr
+    return -sign(real(qrel)) * PD.Kp * vec(qrel) - PD.Kd * werr
 end
 
 function decompose_torque(τ, b, msaturation)

--- a/src/dynamics.jl
+++ b/src/dynamics.jl
@@ -36,13 +36,13 @@ function rk4_rw(J, w, τ, dt)
 end
 
 # TODO: what if saturation compensation is smaller than the cubesat w from control
-function control_loop(sensors, target_vectors, w, RW::ReactionWheel, I, dt = 0.001)
-    q = estimateq(sensors, target_vectors, w)
-    τ = calculate_torque(PDController(), qtarget, q, w, wtarget)
-    τw, τsm, mtrue = decompose_torque(τ, b, msaturation)
-    compensation = deadzone_compensation(RW) + saturation_compensation(RW)
-    τw = clamp(τw + compensation, -RW.maxtorque, RW.maxtorque)
-    rwfriction = stribeck(RW)
-    @reset RW.w = rk4_rw(RW.J, RW.w, -τw + rwfriction, dt)
-    return rk4(I, w, τw - rwfriction, q, dt) # TODO: update cubesat state with τw + τsm + disturbances
-end
+# function control_loop(sensors, target_vectors, w, RW::ReactionWheel, I, dt = 0.001)
+#     q = estimateq(sensors, target_vectors, w)
+#     τ = calculate_torque(PDController(0.1, 0.001), qtarget, q, w, wtarget)
+#     τw, τsm, mtrue = decompose_torque(τ, b, msaturation)
+#     compensation = deadzone_compensation(RW) + saturation_compensation(RW)
+#     τw = clamp(τw + compensation, -RW.maxtorque, RW.maxtorque)
+#     rwfriction = stribeck(RW)
+#     @reset RW.w = rk4_rw(RW.J, RW.w, -τw + rwfriction, dt)
+#     return rk4(I, w, τw - rwfriction, q, dt) # TODO: update cubesat state with τw + τsm + disturbances
+# end

--- a/src/losses.jl
+++ b/src/losses.jl
@@ -2,5 +2,5 @@ mse(ŷ, y; agg = mean) = agg(abs2.(ŷ .- y))
 
 function qloss(q̂, q)
     relq = q * conj(q̂)
-    return norm(vector(relq))
+    return norm(vec(relq))
 end

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -53,7 +53,7 @@ end
 # TODO: Should this return a view?
 Base.@propagate_inbounds Base.getindex(Q::Quaternion, I) = @view Q.coeffs[I]
 
-@inline Base.length(::Quaternion) = 4
+Base.length(::Quaternion) = 4
 
 Base.real(::Type{Quaternion}) = eltype(Quaternion)
 Base.real(::Type{Quaternion{T}}) where {T} = T

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -98,3 +98,17 @@ Base.isone(Q::Quaternion) = isone(Q[1]) && iszero(Q[2]) && iszero(Q[3]) && iszer
 Base.isnan(Q::Quaternion) = isnan(Q[1]) || isnan(Q[2]) || isnan(Q[3]) || isnan(Q[4])
 Base.isinf(Q::Quaternion) = isinf(Q[1]) || isinf(Q[2]) || isinf(Q[3]) || isinf(Q[4])
 Base.isinteger(Q::Quaternion) = isinteger(Q[1]) && isreal(Q)
+
+function Base.show(io::IO, Q::Quaternion{T}) where T
+    print(io, "{")
+    show(io, T)
+    print(io, "}")
+    print(io, " q1: ")
+    show(io, Q[1])
+    print(io, ", q2: ")
+    show(io, Q[2])
+    print(io, ", q3: ")
+    show(io, Q[3])
+    print(io, ", q4: ")
+    show(io, Q[4])
+end

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -29,14 +29,21 @@ const QuaternionF64 = Quaternion{Float64}
 const QuaternionF32 = Quaternion{Float32}
 const QuaternionF16 = Quaternion{Float16}
 
+Base.zero(::Type{Quaternion{T}}) where {T<:Real} = Quaternion{T}(zero(T), zero(T), zero(T), zero(T))
+Base.zero(Q::Quaternion{T}) where {T<:Real} = Base.zero(typeof(Q))
+
+Base.one(::Type{Quaternion{T}}) where {T<:Real} = Quaternion{T}(one(T), zero(T), zero(T), zero(T))
+Base.one(Q::Quaternion{T}) where {T<:Real} = Base.one(typeof(Q))
+
 # Given a numeric type, return a Quaternion (not instance) specialized on T
 (::Type{Quaternion})(::Type{T}) where {T<:Real} = Quaternion{T}
 # Given a Quaternion specialized on T, return another Quaternion also specialized on T
 (::Type{Quaternion})(::Type{Quaternion{T}}) where {T<:Real} = Quaternion{T}
 
 Base.eltype(::Type{Quaternion{T}}) where {T<:Real} = T
+Base.promote_rule(::Type{Quaternion{T}}, ::Type{S}) where {T<:Real, S<:Real} = Quaternion{promote_type(T, S)}
+Base.promote_rule(::Type{Quaternion{T}}, ::Type{Quaternion{S}}) where {T<:Real, S<:Real} = Quaternion{promote_type(T, S)}
 
-# https://docs.julialang.org/en/v1/devdocs/boundscheck/#Eliding-bounds-checks
 @inline function Base.getindex(Q::Quaternion, i::Integer)
     @boundscheck checkbounds(Q.coeffs, i)
     @inbounds return Q.coeffs[i]
@@ -46,8 +53,48 @@ end
 # TODO: Should this return a view?
 Base.@propagate_inbounds Base.getindex(Q::Quaternion, I) = @view Q.coeffs[I]
 
+@inline Base.length(::Quaternion) = 4
+
 Base.real(::Type{Quaternion}) = eltype(Quaternion)
-Base.real(::Type{Quaternion{T}}) where {T<:Real} = eltype(Quaternion{T})
+Base.real(::Type{Quaternion{T}}) where {T} = T
 Base.real(Q::Quaternion{T}) where {T<:Real} = Q[1]
 Base.imag(Q::Quaternion{T}) where {T<:Real} = @view Q.coeffs[2:4]
 Base.vec(Q::Quaternion{T}) where {T<:Real} = @view Q.coeffs[2:4]
+
+Base.widen(::Type{Quaternion{T}}) where {T} = Quaternion{widen(T)}
+Base.big(::Type{Quaternion{T}}) where {T<:Real} = Quaternion{big(T)}
+Base.big(Q::Quaternion{T}) where {T<:Real} = Quaternion{big(T)}(Q)
+
+Base.conj(Q::Quaternion) = Quaternion(Q[1], -Q[2], -Q[3], -Q[4])
+Base.abs2(Q::Quaternion) = sum(abs2, Q.coeffs)
+# TODO: Should do isnan/isinf checks and scale with max of abs of coeffs?
+Base.abs(Q::Quaternion) = sqrt(abs2(Q))
+Base.inv(Q::Quaternion) = conj(Q) / abs2(Q)
+LinearAlgebra.norm(Q::Quaternion) = abs(Q)
+LinearAlgebra.normalize(Q::Quaternion) = Q / abs(Q)
+
+Base.:-(Q::Quaternion) = Quaternion(-Q.coeffs)
+
+Base.:+(Q1::Quaternion, Q2::Quaternion) = Quaternion(Q1.coeffs + Q2.coeffs)
+Base.:-(Q1::Quaternion, Q2::Quaternion) = Quaternion(Q1.coeffs - Q2.coeffs)
+function Base.:*(Q1::Quaternion, Q2::Quaternion)
+    return Quaternion(
+        Q1[1]*Q2[1] - Q1[2]*Q2[2] - Q1[3]*Q2[3] - Q1[4]*Q2[4],
+        Q1[1]*Q2[2] + Q1[2]*Q2[1] + Q1[3]*Q2[4] - Q1[4]*Q2[3],
+        Q1[1]*Q2[3] - Q1[2]*Q2[4] + Q1[3]*Q2[1] + Q1[4]*Q2[2],
+        Q1[1]*Q2[4] + Q1[2]*Q2[3] - Q1[3]*Q2[2] + Q1[4]*Q2[1])
+end
+
+Base.:/(Q1::Quaternion, Q2::Quaternion) = Q1 * inv(Q2)
+
+Base.:*(Q::Quaternion, r::Real) = Quaternion(Q.coeffs * r)
+Base.:*(r::Real, Q::Quaternion) = Quaternion(Q.coeffs * r)
+Base.:/(Q::Quaternion, r::Real) = Quaternion(Q.coeffs / r)
+
+Base.isreal(Q::Quaternion) = iszero(Q[2]) && iszero(Q[3]) && iszero(Q[4])
+Base.isfinite(Q::Quaternion) = isfinite(Q[1]) && isfinite(Q[2]) && isfinite(Q[3]) && isfinite(Q[4])
+Base.iszero(Q::Quaternion) = iszero(Q[1]) && iszero(Q[2]) && iszero(Q[3]) && iszero(Q[4])
+Base.isone(Q::Quaternion) = isone(Q[1]) && iszero(Q[2]) && iszero(Q[3]) && iszero(Q[4])
+Base.isnan(Q::Quaternion) = isnan(Q[1]) || isnan(Q[2]) || isnan(Q[3]) || isnan(Q[4])
+Base.isinf(Q::Quaternion) = isinf(Q[1]) || isinf(Q[2]) || isinf(Q[3]) || isinf(Q[4])
+Base.isinteger(Q::Quaternion) = isinteger(Q[1]) && isreal(Q)

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -1,91 +1,34 @@
-struct Quaternion{T}
-    q1::T
-    q2::T
-    q3::T
-    q4::T
+# Inspired by @moble and Base.Complex
+
+# Signify standard arithmetic operations should be implemented on it
+abstract type AbstractQuaternion{T<:Number} <: Number end
+
+struct Quaternion{T<:Number} <: AbstractQuaternion{T}
+    coeffs::SVector{4,T}
+    Quaternion{T}(v::SVector{4,T}) where {T<:Number} = new{T}(v)
+    # Always use SVector internally
+    Quaternion{T}(v::A) where {T<:Number, A<:AbstractVector} = new{T}(SVector{4,T}(v))
 end
 
-function Base.show(io::IO, Q::Quaternion)
-    print(io, "q1: ")
-    show(io, Q.q1)
-    print(io, ", q2: ")
-    show(io, Q.q2)
-    print(io, ", q3: ")
-    show(io, Q.q3)
-    print(io, ", q4: ")
-    show(io, Q.q4)
+# Construct without having to specify T
+Quaternion(v::SVector{4,T}) where {T<:Number} = Quaternion{T}(v)
+Quaternion(v::AbstractVector{T}) where {T<:Number} = Quaternion{T}(v)
+
+# Explicitly state type, use SVector promote_rules for mixed types
+(::Type{QT})(w, x, y, z) where {T<:Number, QT<:AbstractQuaternion{T}} = QT(SVector{4,T}(w, x, y, z))
+# Rely on type inference, use SVector promote_rules for mixed types
+function (::Type{QT})(w, x, y, z) where {QT<:AbstractQuaternion}
+    v = SVector{4}(w, x, y, z)
+    return QT{eltype(v)}(v)
 end
 
-Quaternion(xs::Vector) = Quaternion(xs...)
-function Quaternion(q1, q2, q3, q4)
-    promoted_type = promote_type(typeof(q1), typeof(q2), typeof(q3), typeof(q4))
-    return Quaternion{promoted_type}(promote(q1, q2, q3, q4)...)
-end
+coeffs(q::AbstractQuaternion) = getfield(q, :coeffs)
 
-function Base.convert(::Type{Quaternion{T}}, x::T) where {T}
-    return Quaternion(x, x, x, x)
-end
+# Type-preserving copy constructor
+(::Type{QT})(q::QT) where {T<:Number, QT<:AbstractQuaternion{T}} = QT(coeffs(q)...)
+# Type conversion copy constructor
+(::Type{QT})(q::AbstractQuaternion{S}) where {T<:Number, S<:Number, QT<:AbstractQuaternion{T}} = QT(SVector{4, T}(coeffs(q)...))
 
-Base.convert(::Type{Quaternion}, Q::Quaternion) = Q
-function Base.convert(::Type{T}, Q::Quaternion) where {T}
-    return Quaternion{T}(Q.q1, Q.q2, Q.q3, Q.q4)
-end
-
-Quaternion(x::T) where {T} = convert(Quaternion{T}, x)
-Base.convert(::Type{Quaternion{T}}, x::Quaternion{T}) where {T} = x
-Base.eltype(::Type{Quaternion{T}}) where {T} = T
-Base.zero(Q::Quaternion{T}) where {T} = Quaternion(zero(eltype(Q)))
-Base.length(::Quaternion) = 4
-function Base.getindex(Q::Quaternion, i::Int)
-    1 <= i <= 4 || throw(BoundsError(Q, i))
-    i == 1 && return Q.q1
-    i == 2 && return Q.q2
-    i == 3 && return Q.q3
-    i == 4 && return Q.q4
-end
-
-function Base.:*(Q1::Quaternion, Q2::Quaternion)
-    return Quaternion(Q1.q1 * Q2.q1 - Q1.q2 * Q2.q2 - Q1.q3 * Q2.q3 - Q1.q4 * Q2.q4,
-        Q1.q1 * Q2.q2 + Q1.q2 * Q2.q1 + Q1.q3 * Q2.q4 - Q1.q4 * Q2.q3,
-        Q1.q1 * Q2.q3 - Q1.q2 * Q2.q4 + Q1.q3 * Q2.q1 + Q1.q4 * Q2.q2,
-        Q1.q1 * Q2.q4 + Q1.q2 * Q2.q3 - Q1.q3 * Q2.q2 + Q1.q4 * Q2.q1)
-end
-
-Base.:*(Q::Quaternion, n::Number) = Quaternion(Q.q1 * n, Q.q2 * n, Q.q3 * n, Q.q4 * n)
-Base.:*(n::Number, Q::Quaternion) = Q * n
-Base.:/(Q::Quaternion, n::Number) = Quaternion(Q.q1 / n, Q.q2 / n, Q.q3 / n, Q.q4 / n)
-function Base.:+(Q1::Quaternion, Q2::Quaternion)
-    return Quaternion(Q1.q1 + Q2.q1, Q1.q2 + Q2.q2, Q1.q3 + Q2.q3, Q1.q4 + Q2.q4)
-end
-
-Base.:-(Q::Quaternion) = Quaternion(-Q.q1, -Q.q2, -Q.q3, -Q.q4)
-function Base.:-(Q1::Quaternion, Q2::Quaternion)
-    return Quaternion(Q1.q1 - Q2.q1, Q1.q2 - Q2.q2, Q1.q3 - Q2.q3, Q1.q4 - Q2.q4)
-end
-
-function Base.:(==)(Q1::Quaternion, Q2::Quaternion)
-    return Q1.q1 == Q2.q1 && Q1.q2 == Q2.q2 && Q1.q3 == Q2.q3 && Q1.q4 == Q2.q4
-end
-
-Base.conj(Q::Quaternion) = Quaternion(Q.q1, -Q.q2, -Q.q3, -Q.q4)
-LinearAlgebra.norm(Q::Quaternion) = sqrt(Q.q1^2 + Q.q2^2 + Q.q3^2 + Q.q4^2)
-function LinearAlgebra.normalize(Q::Quaternion)
-    qnorm = norm(Q)
-    return Quaternion(Q.q1 / qnorm, Q.q2 / qnorm, Q.q3 / qnorm, Q.q4 / qnorm)
-end
-
-Base.:/(Q1::Quaternion, Q2::Quaternion) = Q1 * conj(Q2) / norm(Q2)^2
-Base.inv(Q::Quaternion) = conj(Q) / norm(Q)^2
-scalar(Q::Quaternion) = Q.q1
-vector(Q::Quaternion) = [Q.q2, Q.q3, Q.q4]
-function rotvec(v::Vector, Q::Quaternion)
-    Q = normalize(Q)
-    return vector(conj(Q) * Quaternion([0; v]) * Q)
-end
-
-function toeuler(Q::Quaternion)
-    roll = atan(2 * (Q.q1 * Q.q2 + Q.q3 * Q.q4), 1 - 2 * (Q.q2^2 + Q.q3^2))
-    pitch = asin(2 * (Q.q1 * Q.q3 - Q.q4 * Q.q2))
-    yaw = atan(2 * (Q.q1 * Q.q4 + Q.q2 * Q.q3), 1 - 2 * (Q.q3^2 + Q.q4^2))
-    return [(roll * 180 / π), (pitch * 180 / π), (yaw * 180 / π)]
-end
+const QuaternionF64 = Quaternion{Float64}
+const QuaternionF32 = Quaternion{Float32}
+const QuaternionF16 = Quaternion{Float16}

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -14,9 +14,21 @@ Quaternion(v::AbstractVector{T}) where {T<:Real} = Quaternion{T}(v)
 
 # Explicitly state type, use SVector promote_rules for mixed types
 Quaternion{T}(w, x, y, z) where {T<:Real} = Quaternion(SVector{4,T}(w, x, y, z))
+Quaternion{T}(x, y, z) where {T<:Real} = Quaternion(SVector{4,T}(zero(x), x, y, z))
+Quaternion{T}(w::Real) where {T<:Real} = Quaternion(SVector{4,T}(w, zero(w), zero(w), zero(w)))
 # Rely on type inference, use SVector promote_rules for mixed types
 function Quaternion(w, x, y, z)
     v = SVector{4}(w, x, y, z)
+    return Quaternion{eltype(v)}(v)
+end
+
+function Quaternion(x, y, z)
+    v = SVector{4}(zero(x), x, y, z)
+    return Quaternion{eltype(v)}(v)
+end
+
+function Quaternion(w::Real)
+    v = SVector{4}(w, zero(w), zero(w), zero(w))
     return Quaternion{eltype(v)}(v)
 end
 
@@ -98,6 +110,11 @@ Base.isone(Q::Quaternion) = isone(Q[1]) && iszero(Q[2]) && iszero(Q[3]) && iszer
 Base.isnan(Q::Quaternion) = isnan(Q[1]) || isnan(Q[2]) || isnan(Q[3]) || isnan(Q[4])
 Base.isinf(Q::Quaternion) = isinf(Q[1]) || isinf(Q[2]) || isinf(Q[3]) || isinf(Q[4])
 Base.isinteger(Q::Quaternion) = isinteger(Q[1]) && isreal(Q)
+
+function rotvec(v::A, Q::Quaternion) where {A<:AbstractVector}
+    Q = normalize(Q)
+    return vec(Q * Quaternion(v[1], v[2], v[3]) * conj(Q))
+end
 
 function Base.show(io::IO, Q::Quaternion{T}) where T
     print(io, "{")

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -10,6 +10,11 @@ struct Quaternion{T<:Number} <: AbstractQuaternion{T}
     Quaternion{T}(v::A) where {T<:Number, A<:AbstractVector} = new{T}(SVector{4,T}(v))
 end
 
+# Given a numeric type, return a QT type (not instance) specialized on T
+(::Type{QT})(::Type{T}) where {T<:Number, QT<:AbstractQuaternion} = QT{T}
+# Given a QT specialized on T, return another QT also specialized on T
+(::Type{QT})(::Type{<:AbstractQuaternion{T}}) where {T<:Number, QT<:AbstractQuaternion} = QT{T}
+
 # Construct without having to specify T
 Quaternion(v::SVector{4,T}) where {T<:Number} = Quaternion{T}(v)
 Quaternion(v::AbstractVector{T}) where {T<:Number} = Quaternion{T}(v)

--- a/src/quaternion.jl
+++ b/src/quaternion.jl
@@ -1,39 +1,37 @@
-# Inspired by @moble and Base.Complex
+# Inspired by Michael Boyle and Base.Complex
 
 # Signify standard arithmetic operations should be implemented on it
-abstract type AbstractQuaternion{T<:Number} <: Number end
-
-struct Quaternion{T<:Number} <: AbstractQuaternion{T}
+struct Quaternion{T<:Real} <: Number
     coeffs::SVector{4,T}
-    Quaternion{T}(v::SVector{4,T}) where {T<:Number} = new{T}(v)
+    Quaternion{T}(v::SVector{4,T}) where {T<:Real} = new{T}(v)
     # Always use SVector internally
-    Quaternion{T}(v::A) where {T<:Number, A<:AbstractVector} = new{T}(SVector{4,T}(v))
+    Quaternion{T}(v::A) where {T<:Real, A<:AbstractVector} = new{T}(SVector{4,T}(v))
 end
-
-# Given a numeric type, return a QT type (not instance) specialized on T
-(::Type{QT})(::Type{T}) where {T<:Number, QT<:AbstractQuaternion} = QT{T}
-# Given a QT specialized on T, return another QT also specialized on T
-(::Type{QT})(::Type{<:AbstractQuaternion{T}}) where {T<:Number, QT<:AbstractQuaternion} = QT{T}
 
 # Construct without having to specify T
-Quaternion(v::SVector{4,T}) where {T<:Number} = Quaternion{T}(v)
-Quaternion(v::AbstractVector{T}) where {T<:Number} = Quaternion{T}(v)
+Quaternion(v::SVector{4,T}) where {T<:Real} = Quaternion{T}(v)
+Quaternion(v::AbstractVector{T}) where {T<:Real} = Quaternion{T}(v)
 
 # Explicitly state type, use SVector promote_rules for mixed types
-(::Type{QT})(w, x, y, z) where {T<:Number, QT<:AbstractQuaternion{T}} = QT(SVector{4,T}(w, x, y, z))
+(::Type{Quaternion{T}})(w, x, y, z) where {T<:Real} = Quaternion(SVector{4,T}(w, x, y, z))
 # Rely on type inference, use SVector promote_rules for mixed types
-function (::Type{QT})(w, x, y, z) where {QT<:AbstractQuaternion}
+function (::Type{Quaternion})(w, x, y, z)
     v = SVector{4}(w, x, y, z)
-    return QT{eltype(v)}(v)
+    return Quaternion{eltype(v)}(v)
 end
 
-coeffs(q::AbstractQuaternion) = getfield(q, :coeffs)
+coeffs(q::Quaternion) = getfield(q, :coeffs)
 
 # Type-preserving copy constructor
-(::Type{QT})(q::QT) where {T<:Number, QT<:AbstractQuaternion{T}} = QT(coeffs(q)...)
+Quaternion{T}(q::Quaternion{T}) where {T<:Real} = Quaternion(coeffs(q)...)
 # Type conversion copy constructor
-(::Type{QT})(q::AbstractQuaternion{S}) where {T<:Number, S<:Number, QT<:AbstractQuaternion{T}} = QT(SVector{4, T}(coeffs(q)...))
+Quaternion{T}(q::Quaternion{S}) where {T<:Real, S<:Real} = Quaternion(SVector{4, T}(coeffs(q)...))
 
 const QuaternionF64 = Quaternion{Float64}
 const QuaternionF32 = Quaternion{Float32}
 const QuaternionF16 = Quaternion{Float16}
+
+# Given a numeric type, return a Quaternion (not instance) specialized on T
+(::Type{Quaternion})(::Type{T}) where {T<:Real} = Quaternion{T}
+# Given a Quaternion specialized on T, return another Quaternion also specialized on T
+(::Type{Quaternion})(::Type{Quaternion{T}}) where {T<:Real} = Quaternion{T}

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -20,7 +20,7 @@ function run_groundtruth_simulation(params)
     q = Quaternion([1.0, 0, 0, 0])
     JD = 2459921.0
     n_orbits = 2
-    _, epc, eci = calculate_orbit(JD, n_orbits)
+    _, epc, eci = calculate_orbit(JD, n_orbits, 0.001)
     r_eci = eci[1:3, :]
     r_eci = [r_eci[:, i] for i in 1:size(r_eci, 2)]
     rotation_eci2ecef = rECItoECEF.(epc)


### PR DESCRIPTION
```julia
# Create a Quaternion and infer coefficient type
julia> Quaternion(1,2,3,4)
Quaternion{Int64}([1, 2, 3, 4])

# ... or explicitly specify it
julia> Quaternion{Float64}(1,2,3,4)
QuaternionF64([1.0, 2.0, 3.0, 4.0])

# Instead of 4 arguments, use an AbstractVector to create the Quaternion
julia> Quaternion([1,2,3,4])
Quaternion{Int64}([1, 2, 3, 4])

# ... you can, again, explicitly specify the type or let it infer
julia> Quaternion{Float64}([1,2,3,4])
QuaternionF64([1.0, 2.0, 3.0, 4.0])

# You can create a Quaternion from an SVector directly
julia> Quaternion(SVector{4,Float64}(1,2,3,4))
QuaternionF64([1.0, 2.0, 3.0, 4.0])

julia> Quaternion(SVector{4,Int64}(1,2,3,4))
Quaternion{Int64}([1, 2, 3, 4])

julia> Quaternion{Float64}(SVector{4,Int64}(1,2,3,4))
QuaternionF64([1.0, 2.0, 3.0, 4.0])

# Copy a Quaternion, type-preserving
julia> q2 = Quaternion{Float64}(SVector{4,Int64}(1,2,3,4))
QuaternionF64([1.0, 2.0, 3.0, 4.0])

julia> q2
QuaternionF64([1.0, 2.0, 3.0, 4.0])

julia> q3 = Quaternion(q2)
QuaternionF64([1.0, 2.0, 3.0, 4.0])

# ... or explicitly state the coefficient type of the copy
julia> q4 = Quaternion{Int64}(q3)
Quaternion{Int64}([1, 2, 3, 4])

# Every Quaternion is represented as an SVector
julia> Quaternion([1,2,3,4]).coeffs
4-element SVector{4, Int64} with indices SOneTo(4):
 1
 2
 3
 4

julia> Quaternion(1,2,3,4).coeffs
4-element SVector{4, Int64} with indices SOneTo(4):
 1
 2
 3
 4

# There's automatic conversion using SVector promote rules for mixed types
julia> Quaternion(1,2,3,4.0)
QuaternionF64([1.0, 2.0, 3.0, 4.0])

# Some handy aliases
julia> QuaternionF16
QuaternionF16 (alias for Quaternion{Float16})

julia> QuaternionF32
QuaternionF32 (alias for Quaternion{Float32})

julia> QuaternionF64
QuaternionF64 (alias for Quaternion{Float64})

# Given a numeric type, return a Quaternion (not instance) specialized on T
julia> Quaternion(Float64)
QuaternionF64 (alias for Quaternion{Float64})
# Given a Quaternion specialized on T, return another Quaternion also specialized on T
julia> Quaternion(Quaternion{Int64})
Quaternion{Int64}

# eltype support
julia> eltype(Quaternion)
Quaternion

julia> eltype(QuaternionF64)
Float64

julia> eltype(Quaternion(1,2,3,4))
Int64

# Indexing
julia> Quaternion(3,4,5,6)[2]
4
# Note that the error comes from SVector itself, as it should!
julia> Quaternion(3,4,5,6)[5]
ERROR: BoundsError: attempt to access 4-element SVector{4, Int64} with indices SOneTo(4) at index [5]
Stacktrace:
 [1] throw_boundserror(A::SVector{4, Int64}, I::Tuple{Int64})
   @ Base ./abstractarray.jl:734
 [2] checkbounds
   @ Base ./abstractarray.jl:699 [inlined]
 [3] getindex(Q::Quaternion{Int64}, i::Int64)
   @ Main ./REPL[15]:2
 [4] top-level scope
   @ REPL[33]:1
# Indices that are not integers (such as range) return a view
julia> Quaternion(3,4,5,6)[1:3]
3-element view(::SVector{4, Int64}, 1:3) with eltype Int64:
 3
 4
 5
 
# real for Type
julia> real(Quaternion)
Quaternion

julia> real(QuaternionF64)
Float64

# ... and for instance
julia> real(Quaternion(1,2,3,4))
1

# imag and vec overloads return view
julia> imag(Quaternion(1,2,3,4))
3-element view(::SVector{4, Int64}, 2:4) with eltype Int64:
 2
 3
 4

julia> vec(Quaternion(1,2,3,4))
3-element view(::SVector{4, Int64}, 2:4) with eltype Int64:
 2
 3
 4
```