### PR TITLE
Use StaticArrays wherever possible

### DIFF
--- a/src/ADCSSims.jl
+++ b/src/ADCSSims.jl
@@ -11,6 +11,7 @@ using SatelliteDynamics
 using SatelliteToolboxGeomagneticField
 using SatelliteToolboxGravityModels
 
+using BenchmarkTools
 using Infiltrator
 
 using Dates

--- a/src/control.jl
+++ b/src/control.jl
@@ -5,7 +5,7 @@ end
 
 function calculate_torque(PD::PDController, qtarget, qestimated, w, wtarget, qeci2body)
     qrel = qestimated * conj(qtarget)
-    w_io_i = [0.0, -0.00014277091387915417, 0.0010992751451387854] # w of orbit frame, rad/s
+    w_io_i = @SVector [0.0, -0.00014277091387915417, 0.0010992751451387854] # w of orbit frame, rad/s
     w_io_b = rotvec(w_io_i, qeci2body)
     wrel = w - w_io_b
     werr = wrel - wtarget

--- a/src/disturbances.jl
+++ b/src/disturbances.jl
@@ -20,7 +20,7 @@ function gravity_gradient_tensor(model, p, t, max_degree, P, dP; δ=1e-3)
 
         @. T[:, i] = (g_forward - g_backward) / (2δ)
     end
-    return T
+    return SMatrix(T)
 end
 
 function gravity_torque(G_ecef, R_ecef_to_body, I)

--- a/src/dynamics.jl
+++ b/src/dynamics.jl
@@ -46,9 +46,10 @@ function control_loop(Mode::Type{<:PointingMode}, PA::PointingArguments, PD, qec
     τw = clamp.(τw + compensation, -RW.maxtorque, RW.maxtorque)
     # rwfriction = stribeck(RW)
     @reset RW.w = rk4_rw(RW.J, RW.w, -τw, dt)
-    τrmd = residual_dipole([-0.1235, 0.2469, -0.2273], b)
+    m = @SVector [-0.1235, 0.2469, -0.2273]
+    τrmd = residual_dipole(m, b)
     G_ecef = gravity_gradient_tensor(model, r_ecef, epc, max_degree, P, dP)
-    R_ecef_to_body = to_rotation_matrix(qeci2body) * R_ecef_to_eci
+    R_ecef_to_body = to_rotation_matrix(qeci2body) * SMatrix{3,3}(R_ecef_to_eci)
     τgravity = gravity_torque(G_ecef, R_ecef_to_body, I)
     return rk4(I, w, τw + τsm + τrmd + τgravity, qeci2body, dt), τw, τsm, res, RW, τgravity, τrmd # TODO: update cubesat state with τw + τsm + disturbances
 end

--- a/src/frames.jl
+++ b/src/frames.jl
@@ -1,5 +1,5 @@
 function align_frame_with_vector(target_primary, target_secondary, axis_primary, axis_secondary)
-    target_primary = normalize(target_primary)
+    normalize!(target_primary)
     target_secondary = normalize(target_secondary)
     axis1 = normalize(cross(axis_primary, target_primary))
     angle1 = acos(dot(axis_primary, target_primary))
@@ -11,5 +11,5 @@ function align_frame_with_vector(target_primary, target_secondary, axis_primary,
     angle2 = acos(dot(secondary_intermediate, secondary_perpendicular))
     q2 = Quaternion(axis2, angle2)
     
-    q = q2 * q1
+    return q2 * q1
 end 

--- a/src/main.jl
+++ b/src/main.jl
@@ -1,7 +1,8 @@
 using ADCSSims
+using BenchmarkTools
+using JET
 using DataFrames
 using CSV
-using Base.Iterators: partition
 
 const jd = 2459921.01
 const norbits = 1
@@ -23,13 +24,13 @@ const n_max_dP = 1
 P = Matrix{Float64}(undef, n_max_dP + 1, n_max_dP + 1)
 dP = Matrix{Float64}(undef, n_max_dP + 1, n_max_dP + 1)
 
-const PD = PDController(0.2, 1.0) # SMatrix{3,3}(I(3))
+const PD = PDController(0.2, 1.0)
 const qeci2body = one(QuaternionF64)
 const w = ADCSSims.@MVector [0.0, 0.0, 0.0]
 const state, τw, τsm, τgravs, τrmds = ADCSSims.rotational_dynamics(qeci2body, w, SunPointing, PD, vsunpre..., dt, qtarget, egm2008, n_max_dP, P, dP)
 const state2, τw2, τsm2, τgravs2, τrmds2 = ADCSSims.rotational_dynamics(state[end][2], state[end][1], CamPointing, PD, vimage..., dt, qtarget, egm2008, n_max_dP, P, dP)
 const state3, τw3, τsm3, τgravs3, τrmds3 = ADCSSims.rotational_dynamics(state2[end][2], state2[end][1], GSPointing, PD, vgs..., dt, qtarget, egm2008, n_max_dP, P, dP)
-const state4, τw4, τsm4, τgravs4, τrmds4 = ADCSSims.rotational_dynamics(state3[end][2], state3[end][1], SunPointing, PD, vsunpost..., dt, qtarget, egm2008, n_max_dP, P, dP)
+const state4, τw4, τsm4, τgravs4, τrmds4 = ADCSSims.rotational_dynamics(state3[end][2], state3[end][1], SunPointing, PD, vsunpost..., dt,   qtarget, egm2008, n_max_dP, P, dP)
 
 state_full = [state; state2; state3; state4]
 

--- a/src/simulation.jl
+++ b/src/simulation.jl
@@ -1,5 +1,5 @@
-function calculate_orbit(JD, n_orbits, dt)
-    epc0 = Epoch(jd_to_caldate(JD)...)
+function calculate_orbit(jd, n_orbits, dt)
+    epc0 = Epoch(jd_to_caldate(jd)...)
     oe0 = [R_EARTH + 522863.7, 0.01, 98.0, 306.615, 314.19, 99.89]
     eci0 = sOSCtoCART(oe0, use_degrees=true)
     T = orbit_period(oe0[1])
@@ -109,7 +109,7 @@ function rotational_dynamics(qeci2body, w, pointing_mode, PD, t, epc::Vector{Epo
     Ixy = 0.000147
     Iyz = -0.000086
     Izx = 0.024513
-    inertia_matrix = [[Ixx, Ixy, Izx] [Ixy, Iyy, Iyz] [Izx, Iyz, Izz]]
+    inertia_matrix = @SMatrix [[Ixx, Ixy, Izx] [Ixy, Iyy, Iyz] [Izx, Iyz, Izz]]
     iters = length(t)
     state_history = Vector{Tuple{typeof(w),typeof(qeci2body)}}(undef, iters)
     τw = Vector{Vector{Float64}}(undef, iters)
@@ -120,9 +120,9 @@ function rotational_dynamics(qeci2body, w, pointing_mode, PD, t, epc::Vector{Epo
 
     t = epoch_to_datetime(epc)
     for i in 1:iters
-        nadir_body = Vector(-rotvec(normalize(r_eci[i]), qeci2body))
+        nadir_body = -rotvec(normalize(r_eci[i]), qeci2body)
         sun_body = Vector(rotvec(sun_eci[i], qeci2body))
-        mag_body = Vector(rotvec(mag_eci[i], qeci2body))
+        mag_body = rotvec(mag_eci[i], qeci2body)
         qeci2orbit = Qeci2orbit[i]
         PA = PointingArguments(DynamicPointingArgs(sun_body, nadir_body, qeci2body, qeci2orbit, r_eci[i]), StaticPointingArgs(60.7483, -0.85803, 41.7614, 26.2208))
         wqeci2body, rτw, rτsm, rres, RW, τgrav, τrmd = control_loop(pointing_mode, PA, PD, qeci2body, qeci2orbit, qtarget, zeros(3), mag_body, 0.66, sensors, (nadir_body, sun_body, sun_body), w, RW, inertia_matrix, model, r_ecef[i], t[i], max_degree, P, dP, R_ecef_to_eci[i], dt)


### PR DESCRIPTION
From:
<img width="634" alt="original" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/049f7671-e531-402d-be89-59be847ecf7c">

To:
<img width="626" alt="final" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/d4abfa2f-bd65-4743-9923-79f9a2ba296a">

<details>

`SVector calculate_torque`:
<img width="622" alt="calculate_torque" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/275d7ab2-32c3-4c25-8d37-bdc05390b397">

with `SMatrix(MMatrix)` in `gravity_gradient_tensor`:
<img width="624" alt="gravity_gradient_tensor" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/82b13a9c-e91e-4640-8b2c-a05483dd4e1c">

with `SMatrix inertia_matrix`:
<img width="620" alt="inertia_matrix" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/343beaec-29eb-43a5-9a53-97665d8238cd">

with `SMatrix` in `to_rotation_matrix(qeci2body) * SMatrix{3,3}(R_ecef_to_eci)`:
<img width="624" alt="to_rotation_matrix" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/4cc30743-60a0-4e56-b8f8-e7fdf64a74f7">

with `SVector mag_body` (used in `residual_dipole`):
<img width="621" alt="mag_body" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/fefd1fbb-2433-4444-a4e9-a46a4787050f">

with `SVector nadir_body` (used in `align_frame_with_vector`) and `normalize!(target_primary)` in `align_frame_with_vector` where `target_primary` is a `Vector` (`sun_body`):
<img width="617" alt="nadir_body" src="https://github.com/EMTech-AUTh/ADCSSims.jl/assets/54778816/4074b0db-56a6-44b7-860a-b688142e7c41">

</details>